### PR TITLE
QueryDSL 과제 제출

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+services:
+  mysql:
+    image: mysql:8.0
+    container_name: mysql_container
+    restart: always
+    environment:
+      MYSQL_ROOT_PASSWORD: 12345
+      MYSQL_DATABASE: hellogsmassignment
+      MYSQL_USER: user
+      MYSQL_PASSWORD: 12345
+    ports:
+      - "3306:3306"
+    volumes:
+      - mysql_data:/var/lib/mysql
+
+volumes:
+  mysql_data:

--- a/src/main/java/team/themoment/hellogsmassignment/domain/order/controller/OrderController.java
+++ b/src/main/java/team/themoment/hellogsmassignment/domain/order/controller/OrderController.java
@@ -11,7 +11,6 @@ import team.themoment.hellogsmassignment.domain.order.service.OrderService;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 
 @RestController
 @RequestMapping("/order")
@@ -20,6 +19,13 @@ public class OrderController {
 
     private final OrderService orderService;
 
+    @GetMapping("/legacy/{order_id}")
+    public ResponseEntity<QueryOrderResDto> getOrderByIdLegacy(
+            @PathVariable("order_id") Long orderId
+    ) {
+        QueryOrderResDto response = orderService.queryOrderLegacy(orderId);
+        return ResponseEntity.ok(response);
+    }
     @GetMapping("/{order_id}")
     public ResponseEntity<QueryOrderResDto> getOrderById(
             @PathVariable("order_id") Long orderId
@@ -40,6 +46,20 @@ public class OrderController {
 
         PageRequest pageable = PageRequest.of(page, size);
         SearchOrdersResDto response = orderService.searchOrders(status, minPrice, maxPrice, startDate, endDate, pageable);
+        return ResponseEntity.ok(response);
+    }
+    @GetMapping("/legacy/search")
+    public ResponseEntity<SearchOrdersResDto> searchOrdersLegacy(
+            @RequestParam(required = false) OrderStatus status,
+            @RequestParam(required = false) BigDecimal minPrice,
+            @RequestParam(required = false) BigDecimal maxPrice,
+            @RequestParam(required = false) LocalDate startDate,
+            @RequestParam(required = false) LocalDate endDate,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size) {
+
+        PageRequest pageable = PageRequest.of(page, size);
+        SearchOrdersResDto response = orderService.searchOrdersLegacy(status, minPrice, maxPrice, startDate, endDate, pageable);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/team/themoment/hellogsmassignment/domain/order/repo/OrderRepository.java
+++ b/src/main/java/team/themoment/hellogsmassignment/domain/order/repo/OrderRepository.java
@@ -7,11 +7,12 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import team.themoment.hellogsmassignment.domain.order.entity.Order;
 import team.themoment.hellogsmassignment.domain.order.entity.type.OrderStatus;
+import team.themoment.hellogsmassignment.domain.order.repo.custom.CustomOrderRepository;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 
-public interface OrderRepository extends JpaRepository<Order, Long> {
+public interface OrderRepository extends JpaRepository<Order, Long>, CustomOrderRepository {
 
     @Query("SELECT o FROM Order o " +
             "WHERE (:status IS NULL OR o.status = :status) " +
@@ -19,12 +20,12 @@ public interface OrderRepository extends JpaRepository<Order, Long> {
             "AND (:maxPrice IS NULL OR o.totalPrice <= :maxPrice) " +
             "AND (:startDate IS NULL OR o.createdTime >= :startDate) " +
             "AND (:endDate IS NULL OR o.createdTime <= :endDate)")
-    Page<Order> searchOrders(@Param("status") OrderStatus status,
-                             @Param("minPrice") BigDecimal minPrice,
-                             @Param("maxPrice") BigDecimal maxPrice,
-                             @Param("startDate") LocalDateTime startDate,
-                             @Param("endDate") LocalDateTime endDate,
-                             Pageable pageable);
+    Page<Order> searchOrdersLegacy(@Param("status") OrderStatus status,
+                                   @Param("minPrice") BigDecimal minPrice,
+                                   @Param("maxPrice") BigDecimal maxPrice,
+                                   @Param("startDate") LocalDateTime startDate,
+                                   @Param("endDate") LocalDateTime endDate,
+                                   Pageable pageable);
 
     @Query("SELECT count(*) FROM Order o " +
             "WHERE (:status IS NULL OR o.status = :status) " +
@@ -32,10 +33,10 @@ public interface OrderRepository extends JpaRepository<Order, Long> {
             "AND (:maxPrice IS NULL OR o.totalPrice <= :maxPrice) " +
             "AND (:startDate IS NULL OR o.createdTime >= :startDate) " +
             "AND (:endDate IS NULL OR o.createdTime <= :endDate)")
-    int countSearchOrder(@Param("status") OrderStatus status,
-                             @Param("minPrice") BigDecimal minPrice,
-                             @Param("maxPrice") BigDecimal maxPrice,
-                             @Param("startDate") LocalDateTime startDate,
-                             @Param("endDate") LocalDateTime endDate);
+    int countSearchOrderLegacy(@Param("status") OrderStatus status,
+                               @Param("minPrice") BigDecimal minPrice,
+                               @Param("maxPrice") BigDecimal maxPrice,
+                               @Param("startDate") LocalDateTime startDate,
+                               @Param("endDate") LocalDateTime endDate);
 
 }

--- a/src/main/java/team/themoment/hellogsmassignment/domain/order/repo/custom/CustomOrderRepository.java
+++ b/src/main/java/team/themoment/hellogsmassignment/domain/order/repo/custom/CustomOrderRepository.java
@@ -1,0 +1,15 @@
+package team.themoment.hellogsmassignment.domain.order.repo.custom;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import team.themoment.hellogsmassignment.domain.order.entity.Order;
+import team.themoment.hellogsmassignment.domain.order.entity.type.OrderStatus;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+public interface CustomOrderRepository {
+    Optional<Order> findByIdWithDetails(Long orderId);
+    Page<Order> searchOrders(OrderStatus status, BigDecimal minPrice, BigDecimal maxPrice, LocalDateTime startDate, LocalDateTime endDate, Pageable pageable);
+}

--- a/src/main/java/team/themoment/hellogsmassignment/domain/order/repo/custom/impl/CustomOrderRepositoryImpl.java
+++ b/src/main/java/team/themoment/hellogsmassignment/domain/order/repo/custom/impl/CustomOrderRepositoryImpl.java
@@ -1,0 +1,64 @@
+package team.themoment.hellogsmassignment.domain.order.repo.custom.impl;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import team.themoment.hellogsmassignment.domain.order.entity.Order;
+import team.themoment.hellogsmassignment.domain.order.entity.type.OrderStatus;
+import team.themoment.hellogsmassignment.domain.order.repo.custom.CustomOrderRepository;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static team.themoment.hellogsmassignment.domain.member.entity.QMember.member;
+import static team.themoment.hellogsmassignment.domain.order.entity.QOrder.order;
+import static team.themoment.hellogsmassignment.domain.order.entity.QOrderItem.orderItem;
+import static team.themoment.hellogsmassignment.domain.product.entity.QProduct.product;
+
+@RequiredArgsConstructor
+public class CustomOrderRepositoryImpl implements CustomOrderRepository {
+    private final JPAQueryFactory queryFactory;
+    @Override
+    public Optional<Order> findByIdWithDetails(Long orderId) {
+        Order fetchOrder = queryFactory.selectFrom(order)
+                .join(order.orderItems, orderItem).fetchJoin()
+                .join(orderItem.product,product).fetchJoin()
+                .join(order.member, member).fetchJoin()
+                .where(order.id.eq(orderId))
+                .fetchOne();
+        return Optional.ofNullable(fetchOrder);
+    }
+
+    @Override
+    public Page<Order> searchOrders(OrderStatus status, BigDecimal minPrice, BigDecimal maxPrice, LocalDateTime startDate, LocalDateTime endDate, Pageable pageable) {
+        List<Order> orders = queryFactory.selectFrom(order)
+                .join(order.orderItems, orderItem).fetchJoin()
+                .join(orderItem.product,product).fetchJoin()
+                .join(order.member, member).fetchJoin()
+                .where(
+                        status != null ? order.status.eq(status) : null,
+                        minPrice != null ? order.totalPrice.goe(minPrice) : null,
+                        maxPrice != null ? order.totalPrice.loe(maxPrice) : null,
+                        startDate != null ? order.createdTime.goe(startDate) : null,
+                        endDate != null ? order.createdTime.loe(endDate) : null
+                )
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+        long count = queryFactory.select(order.count())
+                .from(order)
+                .where(
+                        status != null ? order.status.eq(status) : null,
+                        minPrice != null ? order.totalPrice.goe(minPrice) : null,
+                        maxPrice != null ? order.totalPrice.loe(maxPrice) : null,
+                        startDate != null ? order.createdTime.goe(startDate) : null,
+                        endDate != null ? order.createdTime.loe(endDate) : null
+                )
+                .fetchOne();
+        return new PageImpl<>(orders, pageable, count);
+    }
+}

--- a/src/main/java/team/themoment/hellogsmassignment/domain/order/repo/custom/impl/CustomOrderRepositoryImpl.java
+++ b/src/main/java/team/themoment/hellogsmassignment/domain/order/repo/custom/impl/CustomOrderRepositoryImpl.java
@@ -1,5 +1,6 @@
 package team.themoment.hellogsmassignment.domain.order.repo.custom.impl;
 
+import com.querydsl.core.BooleanBuilder;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -35,29 +36,24 @@ public class CustomOrderRepositoryImpl implements CustomOrderRepository {
 
     @Override
     public Page<Order> searchOrders(OrderStatus status, BigDecimal minPrice, BigDecimal maxPrice, LocalDateTime startDate, LocalDateTime endDate, Pageable pageable) {
+        BooleanBuilder searchCondition = new BooleanBuilder();
+        if(status != null){searchCondition.and(order.status.eq(status));}
+        if(minPrice != null){searchCondition.and(order.totalPrice.goe(minPrice));}
+        if(maxPrice != null){searchCondition.and(order.totalPrice.loe(maxPrice));}
+        if(startDate != null){searchCondition.and(order.createdTime.goe(startDate));}
+        if(endDate != null){searchCondition.and(order.createdTime.loe(endDate));}
+
         List<Order> orders = queryFactory.selectFrom(order)
                 .join(order.orderItems, orderItem).fetchJoin()
                 .join(orderItem.product,product).fetchJoin()
                 .join(order.member, member).fetchJoin()
-                .where(
-                        status != null ? order.status.eq(status) : null,
-                        minPrice != null ? order.totalPrice.goe(minPrice) : null,
-                        maxPrice != null ? order.totalPrice.loe(maxPrice) : null,
-                        startDate != null ? order.createdTime.goe(startDate) : null,
-                        endDate != null ? order.createdTime.loe(endDate) : null
-                )
+                .where(searchCondition)
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .fetch();
         long count = queryFactory.select(order.count())
                 .from(order)
-                .where(
-                        status != null ? order.status.eq(status) : null,
-                        minPrice != null ? order.totalPrice.goe(minPrice) : null,
-                        maxPrice != null ? order.totalPrice.loe(maxPrice) : null,
-                        startDate != null ? order.createdTime.goe(startDate) : null,
-                        endDate != null ? order.createdTime.loe(endDate) : null
-                )
+                .where(searchCondition)
                 .fetchOne();
         return new PageImpl<>(orders, pageable, count);
     }

--- a/src/main/java/team/themoment/hellogsmassignment/domain/order/service/OrderService.java
+++ b/src/main/java/team/themoment/hellogsmassignment/domain/order/service/OrderService.java
@@ -12,7 +12,6 @@ import team.themoment.hellogsmassignment.domain.order.repo.OrderRepository;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.List;
 
 @Service
@@ -22,7 +21,7 @@ public class OrderService {
     private final OrderRepository orderRepository;
 
     @Transactional(readOnly = true)
-    public QueryOrderResDto queryOrder(Long orderId) {
+    public QueryOrderResDto queryOrderLegacy(Long orderId) {
         Order order = orderRepository.findById(orderId)
                 .orElseThrow(() -> new RuntimeException("Order not found"));
 
@@ -45,14 +44,38 @@ public class OrderService {
                 .orderItems(orderItemDtos)
                 .build();
     }
+    @Transactional(readOnly = true)
+    public QueryOrderResDto queryOrder(Long orderId){
+        Order order = orderRepository.findByIdWithDetails(orderId)
+                .orElseThrow(() -> new RuntimeException("Order not found"));
+
+        List<OrderItemDto> orderItemDtos = order.getOrderItems().stream()
+                .map(oi -> OrderItemDto.builder()
+                        .orderItemId(oi.getId())
+                        .price(oi.getPrice())
+                        .quantity(oi.getQuantity())
+                        .productName(oi.getProduct().getName())
+                        .build()
+                ).toList();
+
+        return QueryOrderResDto.builder()
+                .orderId(orderId)
+                .memberName(order.getMember().getName())
+                .email(order.getMember().getEmail())
+                .status(order.getStatus())
+                .totalPrice(order.getTotalPrice())
+                .createdTime(order.getCreatedTime())
+                .orderItems(orderItemDtos)
+                .build();
+    }
 
     @Transactional(readOnly = true)
-    public SearchOrdersResDto searchOrders(
+    public SearchOrdersResDto searchOrdersLegacy(
             OrderStatus status, BigDecimal minPrice, BigDecimal maxPrice,
             LocalDate startDate, LocalDate endDate, Pageable pageable
     ) {
-        Page<Order> orders = orderRepository.searchOrders(status, minPrice, maxPrice, startDate != null ? startDate.atStartOfDay() : null, endDate != null ? endDate.atStartOfDay() : null, pageable);
-        int count = orderRepository.countSearchOrder(status, minPrice, maxPrice, startDate != null ? startDate.atStartOfDay() : null, endDate != null ? endDate.atStartOfDay() : null);
+        Page<Order> orders = orderRepository.searchOrdersLegacy(status, minPrice, maxPrice, startDate != null ? startDate.atStartOfDay() : null, endDate != null ? endDate.atStartOfDay() : null, pageable);
+        int count = orderRepository.countSearchOrderLegacy(status, minPrice, maxPrice, startDate != null ? startDate.atStartOfDay() : null, endDate != null ? endDate.atStartOfDay() : null);
 
         SearchOrderInfoDto searchOrderInfoDto = SearchOrderInfoDto.builder()
                 .totalPages(orders.getTotalPages())
@@ -76,4 +99,31 @@ public class OrderService {
                 .build();
     }
 
+    @Transactional(readOnly = true)
+    public SearchOrdersResDto searchOrders(
+            OrderStatus status, BigDecimal minPrice, BigDecimal maxPrice,
+            LocalDate startDate, LocalDate endDate, Pageable pageable
+    ) {
+        Page<Order> orders = orderRepository.searchOrders(status, minPrice, maxPrice, startDate != null ? startDate.atStartOfDay() : null, endDate != null ? endDate.atStartOfDay() : null, pageable);
+        SearchOrderInfoDto searchOrderInfoDto = SearchOrderInfoDto.builder()
+                .totalPages(orders.getTotalPages())
+                .totalElements((int) orders.getTotalElements())
+                .build();
+
+        List<SearchOrderResDto> searchOrderResDtos = orders.getContent().stream()
+                .map(order -> SearchOrderResDto.builder()
+                        .orderId(order.getId())
+                        .memberName(order.getMember().getName())
+                        .totalPrice(order.getTotalPrice())
+                        .status(order.getStatus())
+                        .createdTime(order.getCreatedTime())
+                        .productCount(order.getOrderItems().size())
+                        .build())
+                .toList();
+
+        return SearchOrdersResDto.builder()
+                .info(searchOrderInfoDto)
+                .orders(searchOrderResDtos)
+                .build();
+    }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,7 +8,10 @@ spring:
     show-sql: true
     hibernate:
       ddl-auto: ${DDL_AUTO:update}
-#  sql:
+    properties:
+      hibernate:
+        format_sql: true
+  #  sql:
 #    init:
 #      mode: always
   datasource:


### PR DESCRIPTION
# 단건 조회 API
## 기존 문제
기존 코드에서는 각 엔티티의 fetch type이 모두 LAZY입니다. api에서 dto를 만들기 위해 Order, Member, OrderItem, Product 모두의 정보가 필요하기 때문에, JPA에선 Lazy loading으로 각 엔티티를 모두 차레대로 쿼리를 날려 불러오게 됩니다.
결과적으로 한번의 주문 조회로 5번의 db 조회가 이루어지는 N+1문제가 발생하게 됩니다.
```
Hibernate: select o1_0.order_id,o1_0.created_time,o1_0.member_id,o1_0.status,o1_0.total_price,o1_0.updated_time from tb_order o1_0 where o1_0.order_id=?
Hibernate: select oi1_0.order_id,oi1_0.order_item_id,oi1_0.price,oi1_0.product_id,oi1_0.quantity from tb_order_item oi1_0 where oi1_0.order_id=?
Hibernate: select p1_0.product_id,p1_0.description,p1_0.name,p1_0.price,p1_0.stock_quantity from tb_product p1_0 where p1_0.product_id=?
Hibernate: select p1_0.product_id,p1_0.description,p1_0.name,p1_0.price,p1_0.stock_quantity from tb_product p1_0 where p1_0.product_id=?
Hibernate: select m1_0.member_id,m1_0.auth_referrer_type,m1_0.birth,m1_0.created_time,m1_0.email,m1_0.name,m1_0.phone_number,m1_0.role,m1_0.sex,m1_0.updated_time from tb_member m1_0 where m1_0.member_id=?
```
## 해결 방법
먼저 CustomOrderRepository와 CustomOrderRepositoryImpl을 만들어 기존 Jpa repository인 OrderRepository가 새로 확장된 기능을 상속받아 사용할 수 있도록 만들었습니다.
```java
    public Optional<Order> findByIdWithDetails(Long orderId) {
        Order fetchOrder = queryFactory.selectFrom(order)
                .join(order.orderItems, orderItem).fetchJoin()
                .join(orderItem.product,product).fetchJoin()
                .join(order.member, member).fetchJoin()
                .where(order.id.eq(orderId))
                .fetchOne();
        return Optional.ofNullable(fetchOrder);
    }
```
구현부에선 위 코드처럼 Order이후에 필요한 OrderItem, Product, Member들을 join하여 한번에 조회하도록 만들었습니다. 코드를 짤 때, 처음 구현은 left join이었지만 엔티티의 관계 부분에서 `nullable=false`를 발견하고 join으로 바꾸었습니다.
마지막으로 아래와 같이 한번의 쿼리로 작동함을 확인했습니다.
```
Hibernate: select o1_0.order_id,o1_0.created_time,o1_0.member_id,m1_0.member_id,m1_0.auth_referrer_type,m1_0.birth,m1_0.created_time,m1_0.email,m1_0.name,m1_0.phone_number,m1_0.role,m1_0.sex,m1_0.updated_time,oi1_0.order_id,oi1_0.order_item_id,oi1_0.price,oi1_0.product_id,p1_0.product_id,p1_0.description,p1_0.name,p1_0.price,p1_0.stock_quantity,oi1_0.quantity,o1_0.status,o1_0.total_price,o1_0.updated_time from tb_order o1_0 join tb_order_item oi1_0 on o1_0.order_id=oi1_0.order_id join tb_product p1_0 on p1_0.product_id=oi1_0.product_id join tb_member m1_0 on m1_0.member_id=o1_0.member_id where o1_0.order_id=?
```
# 검색 API
## 기존문제
단건조회 API와 마찬가지로 Order을 조회할때, N+1문제가 발생하였습니다. 또한 OrderService에서 검색결과에 대한 Dto를 생성하는 도중, 불필요한 count 쿼리가 추가적으로 발생했습니다. (countSearchOrder) 해당 count 쿼리가 불필요한 이유는 jpa에서 `Page`를 생성하기 위해 이미 count 쿼리를 사용했고, 그에 대한 결과를 `page.getTotalElements()`를 통해 얻을 수 있기 때문입니다. 결과적으로 아래처럼 한번의 검색으로 총 7번의 sql 쿼리가 발생하였습니다.
```
Hibernate: select o1_0.order_id,o1_0.created_time,o1_0.member_id,o1_0.status,o1_0.total_price,o1_0.updated_time from tb_order o1_0 where (? is null or o1_0.status=?) and (? is null or o1_0.total_price>=?) and (? is null or o1_0.total_price<=?) and (? is null or o1_0.created_time>=?) and (? is null or o1_0.created_time<=?) limit ?
Hibernate: select count(o1_0.order_id) from tb_order o1_0 where (? is null or o1_0.status=?) and (? is null or o1_0.total_price>=?) and (? is null or o1_0.total_price<=?) and (? is null or o1_0.created_time>=?) and (? is null or o1_0.created_time<=?)
Hibernate: select count(*) from tb_order o1_0 where (? is null or o1_0.status=?) and (? is null or o1_0.total_price>=?) and (? is null or o1_0.total_price<=?) and (? is null or o1_0.created_time>=?) and (? is null or o1_0.created_time<=?)
Hibernate: select m1_0.member_id,m1_0.auth_referrer_type,m1_0.birth,m1_0.created_time,m1_0.email,m1_0.name,m1_0.phone_number,m1_0.role,m1_0.sex,m1_0.updated_time from tb_member m1_0 where m1_0.member_id=?
Hibernate: select oi1_0.order_id,oi1_0.order_item_id,oi1_0.price,oi1_0.product_id,oi1_0.quantity from tb_order_item oi1_0 where oi1_0.order_id=?
Hibernate: select m1_0.member_id,m1_0.auth_referrer_type,m1_0.birth,m1_0.created_time,m1_0.email,m1_0.name,m1_0.phone_number,m1_0.role,m1_0.sex,m1_0.updated_time from tb_member m1_0 where m1_0.member_id=?
Hibernate: select oi1_0.order_id,oi1_0.order_item_id,oi1_0.price,oi1_0.product_id,oi1_0.quantity from tb_order_item oi1_0 where oi1_0.order_id=?
```
## 해결방법
먼저 fetch join을 통해 엔티티들을 한번에 불러오도록 하여 N+1 문제를 해결했습니다. jpa의 자동적인 페이지네이션을 사용 할 수 없기 때문에, count쿼리를 따로 작성하여 전체 수를 구하고 Page 객체를 생성하도록 하였습니다.
```java
        List<Order> orders = queryFactory.selectFrom(order)
                .join(order.orderItems, orderItem).fetchJoin()
                .join(orderItem.product,product).fetchJoin()
                .join(order.member, member).fetchJoin()
                .where(
                        status != null ? order.status.eq(status) : null,
                        minPrice != null ? order.totalPrice.goe(minPrice) : null,
                        maxPrice != null ? order.totalPrice.loe(maxPrice) : null,
                        startDate != null ? order.createdTime.goe(startDate) : null,
                        endDate != null ? order.createdTime.loe(endDate) : null
                )
                .offset(pageable.getOffset())
                .limit(pageable.getPageSize())
                .fetch();
        long count = queryFactory.select(order.count())
                .from(order)
                .where(
                        status != null ? order.status.eq(status) : null,
                        minPrice != null ? order.totalPrice.goe(minPrice) : null,
                        maxPrice != null ? order.totalPrice.loe(maxPrice) : null,
                        startDate != null ? order.createdTime.goe(startDate) : null,
                        endDate != null ? order.createdTime.loe(endDate) : null
                )
                .fetchOne();
        return new PageImpl<>(orders, pageable, count);
```
추가적으로 위 코드에서 검색 파라미터를 검사하는 부분이 중복되어 BooleanBuilder를 통해 하나로 통합하였습니다.
```java
    public Page<Order> searchOrders(OrderStatus status, BigDecimal minPrice, BigDecimal maxPrice, LocalDateTime startDate, LocalDateTime endDate, Pageable pageable) {
        BooleanBuilder searchCondition = new BooleanBuilder();
        if(status != null){searchCondition.and(order.status.eq(status));}
        if(minPrice != null){searchCondition.and(order.totalPrice.goe(minPrice));}
        if(maxPrice != null){searchCondition.and(order.totalPrice.loe(maxPrice));}
        if(startDate != null){searchCondition.and(order.createdTime.goe(startDate));}
        if(endDate != null){searchCondition.and(order.createdTime.loe(endDate));}

        List<Order> orders = queryFactory.selectFrom(order)
                .join(order.orderItems, orderItem).fetchJoin()
                .join(orderItem.product,product).fetchJoin()
                .join(order.member, member).fetchJoin()
                .where(searchCondition)
                .offset(pageable.getOffset())
                .limit(pageable.getPageSize())
                .fetch();
        long count = queryFactory.select(order.count())
                .from(order)
                .where(searchCondition)
                .fetchOne();
        return new PageImpl<>(orders, pageable, count);
    }
```
기존에 추가 count 쿼리가 발생했던 부분도 count쿼리 대신 page의 getTotalElements 메서드를 사용하여 대체하였습니다.
결과적으로 총 7건의 쿼리가 발생하던 api를 2건의 쿼리(검색,count)만 발생하도록 줄였습니다.