### PR TITLE
Querydsl 과제 제출

### DIFF
--- a/src/main/java/team/themoment/hellogsmassignment/domain/order/repo/OrderRepository.java
+++ b/src/main/java/team/themoment/hellogsmassignment/domain/order/repo/OrderRepository.java
@@ -7,11 +7,12 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import team.themoment.hellogsmassignment.domain.order.entity.Order;
 import team.themoment.hellogsmassignment.domain.order.entity.type.OrderStatus;
+import team.themoment.hellogsmassignment.domain.order.repo.custom.repo.CustomOrderRepository;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 
-public interface OrderRepository extends JpaRepository<Order, Long> {
+public interface OrderRepository extends JpaRepository<Order, Long>, CustomOrderRepository {
 
     @Query("SELECT o FROM Order o " +
             "WHERE (:status IS NULL OR o.status = :status) " +

--- a/src/main/java/team/themoment/hellogsmassignment/domain/order/repo/custom/impl/CustomOrderRepositoryImpl.java
+++ b/src/main/java/team/themoment/hellogsmassignment/domain/order/repo/custom/impl/CustomOrderRepositoryImpl.java
@@ -1,0 +1,72 @@
+package team.themoment.hellogsmassignment.domain.order.repo.custom.impl;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+import team.themoment.hellogsmassignment.domain.order.entity.Order;
+import team.themoment.hellogsmassignment.domain.order.entity.type.OrderStatus;
+import team.themoment.hellogsmassignment.domain.order.repo.custom.repo.CustomOrderRepository;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static team.themoment.hellogsmassignment.domain.member.entity.QMember.member;
+import static team.themoment.hellogsmassignment.domain.order.entity.QOrder.order;
+import static team.themoment.hellogsmassignment.domain.order.entity.QOrderItem.orderItem;
+import static team.themoment.hellogsmassignment.domain.product.entity.QProduct.product;
+
+@Repository
+@RequiredArgsConstructor
+public class CustomOrderRepositoryImpl implements CustomOrderRepository {
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Optional<Order> findByOrderId(Long orderId) {
+        return Optional.ofNullable(queryFactory.selectFrom(order)
+                .join(order.member, member).fetchJoin()
+                .join(order.orderItems, orderItem).fetchJoin()
+                .join(orderItem.product, product).fetchJoin()
+                .where(order.id.eq(orderId))
+                .fetchOne());
+    }
+
+    @Override
+    public Page<Order> customSearchOrders(
+            OrderStatus status,
+            BigDecimal minPrice,
+            BigDecimal maxPrice,
+            LocalDateTime startDate,
+            LocalDateTime endDate,
+            Pageable pageable
+    ) {
+        BooleanBuilder builder = new BooleanBuilder();
+
+        if (status != null) builder.and(order.status.eq(status));
+        if (minPrice != null) builder.and(order.totalPrice.goe(minPrice));
+        if (maxPrice != null) builder.and(order.totalPrice.loe(maxPrice));
+        if (startDate != null) builder.and(order.createdTime.goe(startDate));
+        if (endDate != null) builder.and(order.createdTime.loe(endDate));
+
+        List<Order> orders = queryFactory.selectFrom(order)
+                .join(order.member, member).fetchJoin()
+                .join(order.orderItems, orderItem).fetchJoin()
+                .join(orderItem.product,product).fetchJoin()
+                .where(builder)
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        long countOrders = queryFactory.select(order.count())
+                .from(order)
+                .where(builder)
+                .fetchOne();
+
+        return new PageImpl<>(orders, pageable, countOrders);
+    }
+}

--- a/src/main/java/team/themoment/hellogsmassignment/domain/order/repo/custom/repo/CustomOrderRepository.java
+++ b/src/main/java/team/themoment/hellogsmassignment/domain/order/repo/custom/repo/CustomOrderRepository.java
@@ -1,0 +1,23 @@
+package team.themoment.hellogsmassignment.domain.order.repo.custom.repo;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import team.themoment.hellogsmassignment.domain.order.entity.Order;
+import team.themoment.hellogsmassignment.domain.order.entity.type.OrderStatus;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+public interface CustomOrderRepository {
+    Optional<Order> findByOrderId(Long orderId);
+
+    Page<Order> customSearchOrders(
+            OrderStatus status,
+            BigDecimal minPrice,
+            BigDecimal maxPrice,
+            LocalDateTime startDate,
+            LocalDateTime endDate,
+            Pageable pageable
+    );
+}

--- a/src/main/java/team/themoment/hellogsmassignment/domain/order/service/OrderService.java
+++ b/src/main/java/team/themoment/hellogsmassignment/domain/order/service/OrderService.java
@@ -9,6 +9,7 @@ import team.themoment.hellogsmassignment.domain.order.dto.response.*;
 import team.themoment.hellogsmassignment.domain.order.entity.Order;
 import team.themoment.hellogsmassignment.domain.order.entity.type.OrderStatus;
 import team.themoment.hellogsmassignment.domain.order.repo.OrderRepository;
+import team.themoment.hellogsmassignment.domain.order.repo.custom.repo.CustomOrderRepository;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -23,7 +24,10 @@ public class OrderService {
 
     @Transactional(readOnly = true)
     public QueryOrderResDto queryOrder(Long orderId) {
-        Order order = orderRepository.findById(orderId)
+//        Order order = orderRepository.findById(orderId)
+//                .orElseThrow(() -> new RuntimeException("Order not found"));
+
+        Order order = orderRepository.findByOrderId(orderId)
                 .orElseThrow(() -> new RuntimeException("Order not found"));
 
         List<OrderItemDto> orderItemDtos = order.getOrderItems().stream()
@@ -51,12 +55,12 @@ public class OrderService {
             OrderStatus status, BigDecimal minPrice, BigDecimal maxPrice,
             LocalDate startDate, LocalDate endDate, Pageable pageable
     ) {
-        Page<Order> orders = orderRepository.searchOrders(status, minPrice, maxPrice, startDate != null ? startDate.atStartOfDay() : null, endDate != null ? endDate.atStartOfDay() : null, pageable);
-        int count = orderRepository.countSearchOrder(status, minPrice, maxPrice, startDate != null ? startDate.atStartOfDay() : null, endDate != null ? endDate.atStartOfDay() : null);
+        Page<Order> orders = orderRepository.customSearchOrders(status, minPrice, maxPrice, startDate != null ? startDate.atStartOfDay() : null, endDate != null ? endDate.atStartOfDay() : null, pageable);
+//        int count = orderRepository.countSearchOrder(status, minPrice, maxPrice, startDate != null ? startDate.atStartOfDay() : null, endDate != null ? endDate.atStartOfDay() : null);
 
         SearchOrderInfoDto searchOrderInfoDto = SearchOrderInfoDto.builder()
                 .totalPages(orders.getTotalPages())
-                .totalElements(count)
+                .totalElements(orders.getTotalPages())
                 .build();
 
         List<SearchOrderResDto> searchOrderResDtos = orders.getContent().stream()


### PR DESCRIPTION
## QueryDSL로 마이그레이션 중 성능 문제 해결 과정 

### N+1 문제

기존에는 fetchType이 Lazy로 설정되어 있었습니다. Lazy로 설정할 경우, 지연 로딩으로 인해 모든 엔티티에 각각 쿼리문을 날려 예상보다 많은 쿼리문이 발생하게 됩니다. 

이 문제를 QueryDSL의 fetchJoin을 사용하여 단일 쿼리문으로 불러올 수 있도록 설정하였습니다.

```java
Optional.ofNullable(queryFactory.selectFrom(order)
            .join(order.member, member).fetchJoin()
            .join(order.orderItems, orderItem).fetchJoin()
            .join(orderItem.product, product).fetchJoin()
            .where(order.id.eq(orderId))
            .fetchOne());
```

주문 검색 API도 비슷한 문제가 발생하여 fetchJoin을 사용하여 단일 쿼리문으로 불러올 수 있도록 설정하였습니다.
그리고 BooleanBuilder를 이용하여 null인지 검사를 하고 BooleanBuilder의 and를 사용하여 조건들을 추가하였습니다. 
```java
BooleanBuilder builder = new BooleanBuilder();

if (status != null) builder.and(order.status.eq(status));
if (minPrice != null) builder.and(order.totalPrice.goe(minPrice));
if (maxPrice != null) builder.and(order.totalPrice.loe(maxPrice));
if (startDate != null) builder.and(order.createdTime.goe(startDate));
if (endDate != null) builder.and(order.createdTime.loe(endDate));

List<Order> orders = queryFactory.selectFrom(order)
        .join(order.member, member).fetchJoin()
        .join(order.orderItems, orderItem).fetchJoin()
        .join(orderItem.product,product).fetchJoin()
        .where(builder)
        .offset(pageable.getOffset())
        .limit(pageable.getPageSize())
        .fetch();

long countOrders = queryFactory.select(order.count())
        .from(order)
        .where(builder)
        .fetchOne();

return new PageImpl<>(orders, pageable, countOrders);
```