### PR TITLE
홍지민 : QueryDSL 과제

### DIFF
--- a/src/main/java/team/themoment/hellogsmassignment/domain/order/repo/OrderRepository.java
+++ b/src/main/java/team/themoment/hellogsmassignment/domain/order/repo/OrderRepository.java
@@ -11,31 +11,32 @@ import team.themoment.hellogsmassignment.domain.order.entity.type.OrderStatus;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 
-public interface OrderRepository extends JpaRepository<Order, Long> {
 
-    @Query("SELECT o FROM Order o " +
-            "WHERE (:status IS NULL OR o.status = :status) " +
-            "AND (:minPrice IS NULL OR o.totalPrice >= :minPrice) " +
-            "AND (:maxPrice IS NULL OR o.totalPrice <= :maxPrice) " +
-            "AND (:startDate IS NULL OR o.createdTime >= :startDate) " +
-            "AND (:endDate IS NULL OR o.createdTime <= :endDate)")
-    Page<Order> searchOrders(@Param("status") OrderStatus status,
-                             @Param("minPrice") BigDecimal minPrice,
-                             @Param("maxPrice") BigDecimal maxPrice,
-                             @Param("startDate") LocalDateTime startDate,
-                             @Param("endDate") LocalDateTime endDate,
-                             Pageable pageable);
+public interface OrderRepository extends JpaRepository<Order, Long>, OrderRepositoryCustom {
 
-    @Query("SELECT count(*) FROM Order o " +
-            "WHERE (:status IS NULL OR o.status = :status) " +
-            "AND (:minPrice IS NULL OR o.totalPrice >= :minPrice) " +
-            "AND (:maxPrice IS NULL OR o.totalPrice <= :maxPrice) " +
-            "AND (:startDate IS NULL OR o.createdTime >= :startDate) " +
-            "AND (:endDate IS NULL OR o.createdTime <= :endDate)")
-    int countSearchOrder(@Param("status") OrderStatus status,
-                             @Param("minPrice") BigDecimal minPrice,
-                             @Param("maxPrice") BigDecimal maxPrice,
-                             @Param("startDate") LocalDateTime startDate,
-                             @Param("endDate") LocalDateTime endDate);
+//    @Query("SELECT o FROM Order o " +
+//            "WHERE (:status IS NULL OR o.status = :status) " +
+//            "AND (:minPrice IS NULL OR o.totalPrice >= :minPrice) " +
+//            "AND (:maxPrice IS NULL OR o.totalPrice <= :maxPrice) " +
+//            "AND (:startDate IS NULL OR o.createdTime >= :startDate) " +
+//            "AND (:endDate IS NULL OR o.createdTime <= :endDate)")
+//    Page<Order> searchOrders(@Param("status") OrderStatus status,
+//                             @Param("minPrice") BigDecimal minPrice,
+//                             @Param("maxPrice") BigDecimal maxPrice,
+//                             @Param("startDate") LocalDateTime startDate,
+//                             @Param("endDate") LocalDateTime endDate,
+//                             Pageable pageable);
+//
+//    @Query("SELECT count(*) FROM Order o " +
+//            "WHERE (:status IS NULL OR o.status = :status) " +
+//            "AND (:minPrice IS NULL OR o.totalPrice >= :minPrice) " +
+//            "AND (:maxPrice IS NULL OR o.totalPrice <= :maxPrice) " +
+//            "AND (:startDate IS NULL OR o.createdTime >= :startDate) " +
+//            "AND (:endDate IS NULL OR o.createdTime <= :endDate)")
+//    int countSearchOrder(@Param("status") OrderStatus status,
+//                             @Param("minPrice") BigDecimal minPrice,
+//                             @Param("maxPrice") BigDecimal maxPrice,
+//                             @Param("startDate") LocalDateTime startDate,
+//                             @Param("endDate") LocalDateTime endDate);
 
 }

--- a/src/main/java/team/themoment/hellogsmassignment/domain/order/repo/OrderRepositoryCustom.java
+++ b/src/main/java/team/themoment/hellogsmassignment/domain/order/repo/OrderRepositoryCustom.java
@@ -1,0 +1,20 @@
+package team.themoment.hellogsmassignment.domain.order.repo;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import team.themoment.hellogsmassignment.domain.order.dto.response.SearchOrderResDto;
+import team.themoment.hellogsmassignment.domain.order.entity.type.OrderStatus;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+public interface OrderRepositoryCustom {
+    Page<SearchOrderResDto> searchOrders(
+            OrderStatus status,
+            BigDecimal minPrice,
+            BigDecimal maxPrice,
+            LocalDateTime startDate,
+            LocalDateTime endDate,
+            Pageable pageable
+    );
+}

--- a/src/main/java/team/themoment/hellogsmassignment/domain/order/repo/OrderRepositoryCustomImpl.java
+++ b/src/main/java/team/themoment/hellogsmassignment/domain/order/repo/OrderRepositoryCustomImpl.java
@@ -1,0 +1,110 @@
+package team.themoment.hellogsmassignment.domain.order.repo;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import team.themoment.hellogsmassignment.domain.member.entity.QMember;
+import team.themoment.hellogsmassignment.domain.order.dto.response.SearchOrderResDto;
+import team.themoment.hellogsmassignment.domain.order.entity.QOrder;
+import team.themoment.hellogsmassignment.domain.order.entity.QOrderItem;
+import team.themoment.hellogsmassignment.domain.order.entity.type.OrderStatus;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@RequiredArgsConstructor
+public class OrderRepositoryCustomImpl implements OrderRepositoryCustom{
+    private final JPAQueryFactory queryFactory;
+
+    private final QOrder order = QOrder.order;
+    private final QMember member = QMember.member;
+    private final QOrderItem orderItem = QOrderItem.orderItem;
+
+    @Override
+    public Page<SearchOrderResDto> searchOrders(
+            OrderStatus status, BigDecimal minPrice, BigDecimal maxPrice,
+            LocalDateTime startDate, LocalDateTime endDate, Pageable pageable
+    ) {
+        List<SearchOrderResDto> content = queryFactory
+                .select(Projections.constructor(
+                        SearchOrderResDto.class,
+                        order.id,
+                        member.name,
+                        order.totalPrice,
+                        order.status,
+                        order.createdTime,
+                        orderItem.id.count().intValue()
+                ))
+                .from(order)
+                .join(order.member, member)
+                .leftJoin(order.orderItems, orderItem)
+                .where(
+                        statusEq(status),
+                        minPriceGoe(minPrice),
+                        maxPriceLoe(maxPrice),
+                        createdBetween(startDate, endDate)
+                )
+                .groupBy(order.id, member.name)
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        Long total =
+                queryFactory
+                        .select(order.count())
+                        .from(order)
+                        .where(
+                                statusEq(status),
+                                minPriceGoe(minPrice),
+                                maxPriceLoe(maxPrice),
+                                createdBetween(startDate, endDate)
+                        )
+                        .fetchOne();
+
+        return new PageImpl<>(content, pageable, total);
+    }
+
+    private BooleanExpression statusEq(OrderStatus status) {
+        return status != null ? order.status.eq(status) : null;
+    }
+
+    private BooleanExpression minPriceGoe(BigDecimal minPrice) {
+        return minPrice != null ? order.totalPrice.goe(minPrice) : null;
+    }
+
+    private BooleanExpression maxPriceLoe(BigDecimal maxPrice) {
+        return maxPrice != null ? order.totalPrice.loe(maxPrice) : null;
+    }
+
+    private BooleanExpression startDateGoe(LocalDateTime startDate) {
+        return startDate != null ? order.createdTime.goe(startDate) : null;
+    }
+
+    private BooleanExpression endDateLoe(LocalDateTime endDate) {
+        return endDate != null ? order.createdTime.loe(endDate) : null;
+    }
+
+    private BooleanExpression createdBetween(
+            LocalDateTime startDate,
+            LocalDateTime endDate
+    ) {
+        if (startDate == null && endDate == null) {
+            return null;
+        }
+
+        if (startDate != null && endDate != null) {
+            return QOrder.order.createdTime.between(startDate, endDate);
+        }
+
+        if (startDate != null) {
+            return QOrder.order.createdTime.goe(startDate);
+        }
+
+        return QOrder.order.createdTime.loe(endDate);
+    }
+}

--- a/src/main/java/team/themoment/hellogsmassignment/domain/order/repo/OrderRepositoryCustomImpl.java
+++ b/src/main/java/team/themoment/hellogsmassignment/domain/order/repo/OrderRepositoryCustomImpl.java
@@ -7,10 +7,12 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
-import team.themoment.hellogsmassignment.domain.member.entity.QMember;
+import static team.themoment.hellogsmassignment.domain.member.entity.QMember.member;
 import team.themoment.hellogsmassignment.domain.order.dto.response.SearchOrderResDto;
+import static team.themoment.hellogsmassignment.domain.order.entity.QOrder.order;
+import static team.themoment.hellogsmassignment.domain.order.entity.QOrderItem.orderItem;
+
 import team.themoment.hellogsmassignment.domain.order.entity.QOrder;
-import team.themoment.hellogsmassignment.domain.order.entity.QOrderItem;
 import team.themoment.hellogsmassignment.domain.order.entity.type.OrderStatus;
 
 import java.math.BigDecimal;
@@ -21,9 +23,6 @@ import java.util.List;
 public class OrderRepositoryCustomImpl implements OrderRepositoryCustom{
     private final JPAQueryFactory queryFactory;
 
-    private final QOrder order = QOrder.order;
-    private final QMember member = QMember.member;
-    private final QOrderItem orderItem = QOrderItem.orderItem;
 
     @Override
     public Page<SearchOrderResDto> searchOrders(

--- a/src/main/java/team/themoment/hellogsmassignment/domain/order/service/OrderService.java
+++ b/src/main/java/team/themoment/hellogsmassignment/domain/order/service/OrderService.java
@@ -49,30 +49,22 @@ public class OrderService {
     @Transactional(readOnly = true)
     public SearchOrdersResDto searchOrders(
             OrderStatus status, BigDecimal minPrice, BigDecimal maxPrice,
-            LocalDate startDate, LocalDate endDate, Pageable pageable
+            LocalDateTime startDate, LocalDateTime endDate, Pageable pageable
     ) {
-        Page<Order> orders = orderRepository.searchOrders(status, minPrice, maxPrice, startDate != null ? startDate.atStartOfDay() : null, endDate != null ? endDate.atStartOfDay() : null, pageable);
-        int count = orderRepository.countSearchOrder(status, minPrice, maxPrice, startDate != null ? startDate.atStartOfDay() : null, endDate != null ? endDate.atStartOfDay() : null);
+        Page<SearchOrderResDto> page =
+                orderRepository.searchOrders(
+                        status, minPrice, maxPrice,
+                        startDate, endDate, pageable
+                );
 
-        SearchOrderInfoDto searchOrderInfoDto = SearchOrderInfoDto.builder()
-                .totalPages(orders.getTotalPages())
-                .totalElements(count)
+        SearchOrderInfoDto info = SearchOrderInfoDto.builder()
+                .totalPages(page.getTotalPages())
+                .totalElements((int) page.getTotalElements())
                 .build();
 
-        List<SearchOrderResDto> searchOrderResDtos = orders.getContent().stream()
-                .map(order -> SearchOrderResDto.builder()
-                        .orderId(order.getId())
-                        .memberName(order.getMember().getName())
-                        .totalPrice(order.getTotalPrice())
-                        .status(order.getStatus())
-                        .createdTime(order.getCreatedTime())
-                        .productCount(order.getOrderItems().size())
-                        .build())
-                .toList();
-
         return SearchOrdersResDto.builder()
-                .info(searchOrderInfoDto)
-                .orders(searchOrderResDtos)
+                .info(info)
+                .orders(page.getContent())
                 .build();
     }
 


### PR DESCRIPTION
## 주문 검색 API QueryDSL 마이그레이션

### QueryDSL 개념 설명

QueryDSL은 JPQL이나 SQL을 문자열로 작성하는 방식이 아니라,
자바 코드로 쿼리를 구성할 수 있도록 지원하는 타입 세이프(Query Type-safe) 쿼리 빌더입니다.

엔티티를 기반으로 생성된 Q클래스를 사용해 필드 접근이 컴파일 타임에 검증되며,
잘못된 필드명이나 타입 오류를 사전에 방지할 수 있습니다.

또한 조건을 코드 단위로 분리하여 조합할 수 있기 때문에,
동적 검색 조건이 많은 조회 로직에서 가독성과 유지보수성이 크게 향상됩니다.

이번 변경에서는 이러한 특성을 활용해
복잡해진 주문 검색 쿼리를 명확한 구조로 재정리하고,
확장 가능한 조회 로직을 구성하는 데 목적을 두었습니다

---

### 변경 배경
기존 주문 검색 API는 JPQL `@Query` 기반으로 동적 조건을 처리하고 있었습니다.
이 방식은 조건이 늘어날수록 쿼리 문자열이 복잡해지고, 가독성과 유지보수성이 빠르게 저하되는 문제가 있었습니다.

또한 엔티티를 조회한 뒤 서비스 계층에서 DTO로 변환하는 구조로 인해,
조회 책임과 변환 책임이 분리되지 않아 로직이 점점 비대해질 가능성이 있었습니다.

---

### 주요 변경 사항

#### 1. JPQL → QueryDSL 마이그레이션
- 문자열 기반 JPQL 쿼리를 QueryDSL로 변경
- 동적 조건을 `BooleanExpression` 단위로 분리하여 관리
- 조건 추가/삭제 시 쿼리 전체를 수정하지 않아도 되는 구조로 개선

#### 2. DTO 직접 조회 방식 적용
- 엔티티 조회 후 변환하는 방식에서 벗어나 QueryDSL Projection을 통해 DTO를 직접 조회
- 불필요한 엔티티 로딩 제거
- 조회 결과에 필요한 데이터만 명확히 정의된 형태로 반환

#### 3. 페이징 구조 개선
- content 조회 쿼리와 count 쿼리를 분리
- 조회 목적에 맞게 쿼리를 단순화하여 역할을 명확히 분리

---

### 구조 개선 효과
- 검색 조건이 증가하더라도 코드 확장이 용이한 구조
- 조회 로직의 책임이 Repository 계층에 명확히 집중
- 서비스 계층에서는 결과를 조합하여 반환하는 역할만 수행
- 전반적인 코드 가독성 및 유지보수성 향상

---

### 참고 사항
- 기존 API 스펙은 유지됨
- 이후 인덱스 적용 및 추가 최적화를 고려할 수 있는 구조로 개선됨
